### PR TITLE
fix(lib): auto include README from workspace root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Sub-package README files
+packages/lib/README.md

--- a/packages/lib/tsdown.config.ts
+++ b/packages/lib/tsdown.config.ts
@@ -4,5 +4,8 @@ export default defineConfig({
   dts: true,
   entry: 'src/index.ts',
   exports: true,
+  copy: [
+    '../../README.md',
+  ],
   // minify: true,
 })


### PR DESCRIPTION
> An npm package README.md file must be in the root-level directory of the package.[^1]

Use `tsdown`'s copy functionality to copy the README.md to package root.

Ref:
- https://github.com/npm/rfcs/discussions/713

[^1]: https://docs.npmjs.com/about-package-readme-files/